### PR TITLE
Improve function get_rotation_matrix

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,3 +140,5 @@ end
 @testset "test supports" begin
     include("test_supports.jl")
 end
+
+@testset "test_rotation_matrix.jl" begin include("test_rotation_matrix.jl") end

--- a/test/test_rotation_matrix.jl
+++ b/test/test_rotation_matrix.jl
@@ -1,0 +1,16 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/FEMBeam.jl/blob/master/LICENSE
+
+## Rotation matrix test
+
+using FEMBeam
+using FEMBeam: get_rotation_matrix
+using FEMBase.Test
+
+# If tangent vector ``t`` is parallel to the first beam section axis ``n_1``,
+# local basis is not uniquely defined and error is thrown.
+
+X1 = [0.0, 0.0, 0.0]
+X2 = [1.0, 0.0, 0.0]
+n1 = [1.0, 0.0, 0.0]
+@test_throws Exception get_rotation_matrix(X1, X2, n1)


### PR DESCRIPTION
- Added docstring explaining the principles of constructing orthonormal
  local base for defining beam cross-section.
- Now function throws an exception with a clear error message if user
  tries to construct rotation matrix where tangent is parallel to first
  beam section axis n1.
- This commit closes PR #10.