### PR TITLE
change to get beam example running

### DIFF
--- a/src/FEMBeam.jl
+++ b/src/FEMBeam.jl
@@ -16,7 +16,7 @@ Beam implementation for JuliaFEM.
 """
 module FEMBeam
 
-using FEMBase, LinearAlgebra, SparseArrays
+using FEMBase, FEMQuad, LinearAlgebra, SparseArrays
 
 include("get_beam_stiffness_matrix_2d.jl")
 include("get_beam_forces_vector_2d.jl")


### PR DESCRIPTION
as discussed on https://gitter.im/JuliaFEM/JuliaFEM.jl.
the return from 1d integration is now a tuple instead of a scalar.
added dependency for FEMQuad